### PR TITLE
feat: implement top page

### DIFF
--- a/components/SectionCard.tsx
+++ b/components/SectionCard.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import { LucideIcon, ArrowRight } from 'lucide-react'
+
+interface SectionCardProps {
+  href: string
+  icon: LucideIcon
+  title: string
+  description: string
+}
+
+const SectionCard = ({ href, icon: Icon, title, description }: SectionCardProps) => {
+  return (
+    <Link
+      href={href}
+      className="group rounded-lg border border-gray-200 p-6 transition-all hover:border-gray-300 hover:shadow-lg"
+    >
+      <div className="flex flex-col items-center text-center">
+        <div className="rounded-full bg-gray-100 p-3 transition-colors group-hover:bg-gray-200">
+          <Icon className="h-6 w-6 text-gray-700" />
+        </div>
+        <h2 className="mt-4 text-xl font-bold text-gray-900">{title}</h2>
+        <p className="mt-2 text-sm text-gray-600">{description}</p>
+        <div className="mt-4 flex items-center text-sm font-medium text-gray-700 transition-colors group-hover:text-gray-900">
+          詳しく見る
+          <ArrowRight className="ml-1 h-4 w-4" />
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+export { SectionCard }

--- a/components/__tests__/SectionCard.test.tsx
+++ b/components/__tests__/SectionCard.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { SectionCard } from '@/components/SectionCard'
+import { User, Briefcase } from 'lucide-react'
+
+describe('SectionCard', () => {
+  const defaultProps = {
+    href: '/about',
+    icon: User,
+    title: 'ABOUT',
+    description: '私について、経歴、趣味などを紹介します',
+  }
+
+  it('should render as a link with correct href', () => {
+    render(<SectionCard {...defaultProps} />)
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/about')
+  })
+
+  it('should render title as h2 heading', () => {
+    render(<SectionCard {...defaultProps} />)
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'ABOUT' })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('should render description text', () => {
+    render(<SectionCard {...defaultProps} />)
+
+    expect(screen.getByText('私について、経歴、趣味などを紹介します')).toBeInTheDocument()
+  })
+
+  it('should render icon and arrow icon', () => {
+    const { container } = render(<SectionCard {...defaultProps} />)
+
+    // SVGアイコンが2つ存在することを確認（メインアイコン + ArrowRight）
+    const svgElements = container.querySelectorAll('svg')
+    expect(svgElements).toHaveLength(2)
+  })
+
+  it('should render call-to-action text with arrow', () => {
+    render(<SectionCard {...defaultProps} />)
+
+    expect(screen.getByText('詳しく見る')).toBeInTheDocument()
+  })
+
+  it('should render with different icon and props', () => {
+    const customProps = {
+      href: '/work',
+      icon: Briefcase,
+      title: 'WORK',
+      description: 'これまでの制作物やプロジェクトを紹介します',
+    }
+
+    render(<SectionCard {...customProps} />)
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/work')
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'WORK' })
+    expect(heading).toBeInTheDocument()
+
+    expect(screen.getByText('これまでの制作物やプロジェクトを紹介します')).toBeInTheDocument()
+  })
+})

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,65 @@
 import { Layout } from '@/components/Layout'
+import { SectionCard } from '@/components/SectionCard'
+import { User, Briefcase, Code, Mail } from 'lucide-react'
 
 const HomePage = () => {
+  const sections = [
+    {
+      href: '/about',
+      icon: User,
+      title: 'ABOUT',
+      description: '私について、経歴、趣味などを紹介します',
+    },
+    {
+      href: '/work',
+      icon: Briefcase,
+      title: 'WORK',
+      description: 'これまでの制作物やプロジェクトを紹介します',
+    },
+    {
+      href: '/skill',
+      icon: Code,
+      title: 'SKILL',
+      description: '使用できる技術やスキルセットを紹介します',
+    },
+    {
+      href: '/contact',
+      icon: Mail,
+      title: 'CONTACT',
+      description: 'お問い合わせやSNSリンクはこちらから',
+    },
+  ]
+
   return (
     <Layout>
-      <div className="flex flex-col items-center justify-center py-24">
-        <h1 className="text-4xl font-bold">Portfolio</h1>
-        <p className="mt-4 text-lg">基本レイアウトが完成しました</p>
-      </div>
+      {/* ヒーローセクション */}
+      <section className="bg-gradient-to-b from-gray-50 to-white px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl">
+            Welcome to My Portfolio
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-lg text-gray-600">
+            Webエンジニアとして、フロントエンドを中心に開発しています。
+            <br />
+            制作物やスキルをご覧ください。
+          </p>
+        </div>
+      </section>
+
+      {/* セクション紹介 */}
+      <section className="px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto grid max-w-6xl gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          {sections.map((section) => (
+            <SectionCard
+              key={section.href}
+              href={section.href}
+              icon={section.icon}
+              title={section.title}
+              description={section.description}
+            />
+          ))}
+        </div>
+      </section>
     </Layout>
   )
 }


### PR DESCRIPTION
## 概要
トップページの実装を行いました。

## 関連ISSUE
Closes #9

## 変更内容
- ヒーローセクションの追加（グラデーション背景、ウェルカムメッセージ）
- SectionCardコンポーネントの作成（再利用可能なセクションリンク）
- 4つのセクションカードの実装（ABOUT、WORK、SKILL、CONTACT）
- レスポンシブグリッドレイアウトの実装
- ホバーエフェクトとトランジションの追加
- SectionCardコンポーネントのテスト追加
  - リンクhref属性のテスト
  - h2見出し表示のテスト
  - 説明文表示のテスト
  - アイコンとArrowアイコン表示のテスト（2つのSVG）
  - CTA（詳しく見る）表示のテスト
  - 異なるpropsとアイコンでのレンダリングテスト

## テスト結果
```
PASS components/__tests__/SectionCard.test.tsx
  SectionCard
    ✓ should render as a link with correct href
    ✓ should render title as h2 heading
    ✓ should render description text
    ✓ should render icon and arrow icon
    ✓ should render call-to-action text with arrow
    ✓ should render with different icon and props

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
```

## テスト方法
1. `npm test`でテストを実行し、すべてパスすることを確認
2. `npm run dev`でローカルサーバーを起動
3. `http://localhost:3000`にアクセス
4. トップページが正しく表示されることを確認
5. 各セクションカードのホバーエフェクトを確認
6. レスポンシブデザインの動作を確認

## チェックリスト
- [x] コードの動作確認
- [x] コーディング規約に準拠
- [x] 不要なコメントやログの削除
- [x] ビルドエラーがないことを確認
- [x] テストが作成され、すべてパスしている

## 備考
- このPRはPR #19（テスト環境のセットアップ）に依存しています
- PR #19がマージされた後、このPRをマージしてください

🤖 Generated with [Claude Code](https://claude.com/claude-code)