### PR TITLE
feat: implement WORK page with ProjectCard component

### DIFF
--- a/__tests__/pages/work.test.tsx
+++ b/__tests__/pages/work.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import WorkPage from '@/pages/work'
+
+describe('WorkPage', () => {
+  it('should render page title', () => {
+    render(<WorkPage />)
+
+    const heading = screen.getByRole('heading', { level: 1, name: /work/i })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('should render page description', () => {
+    render(<WorkPage />)
+
+    expect(screen.getByText(/これまでの制作物やプロジェクトを紹介します/i)).toBeInTheDocument()
+  })
+
+  it('should render all project cards', () => {
+    render(<WorkPage />)
+
+    // プロジェクトのタイトルを確認
+    expect(screen.getByRole('heading', { level: 3, name: /ポートフォリオサイト/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: /タスク管理アプリ/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: /社内管理システム/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: /天気予報アプリ/i })).toBeInTheDocument()
+  })
+
+  it('should render project categories', () => {
+    render(<WorkPage />)
+
+    const categories = screen.getAllByText(/自主制作|インターンシップ/)
+    expect(categories.length).toBeGreaterThan(0)
+  })
+
+  it('should render project periods', () => {
+    render(<WorkPage />)
+
+    expect(screen.getByText('2024年11月')).toBeInTheDocument()
+    expect(screen.getByText('2024年9月')).toBeInTheDocument()
+  })
+
+  it('should render GitHub links', () => {
+    render(<WorkPage />)
+
+    const githubLinks = screen.getAllByRole('link', { name: /github/i })
+    expect(githubLinks.length).toBeGreaterThan(0)
+  })
+
+  it('should render Demo links', () => {
+    render(<WorkPage />)
+
+    const demoLinks = screen.getAllByRole('link', { name: /demo/i })
+    expect(demoLinks.length).toBeGreaterThan(0)
+  })
+
+  it('should have semantic structure', () => {
+    render(<WorkPage />)
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+  })
+
+  it('should render technology tags', () => {
+    render(<WorkPage />)
+
+    expect(screen.getAllByText('Next.js').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('TypeScript').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('React').length).toBeGreaterThan(0)
+  })
+})

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link'
+import { ExternalLink, Github } from 'lucide-react'
+
+interface ProjectCardProps {
+  title: string
+  description: string
+  technologies: string[]
+  period: string
+  category: string
+  githubUrl?: string
+  demoUrl?: string
+  imageUrl?: string
+}
+
+const ProjectCard = ({
+  title,
+  description,
+  technologies,
+  period,
+  category,
+  githubUrl,
+  demoUrl,
+  imageUrl,
+}: ProjectCardProps) => {
+  return (
+    <div className="group rounded-lg border border-gray-200 bg-white overflow-hidden transition-all hover:shadow-lg">
+      {/* サムネイル画像 */}
+      {imageUrl ? (
+        <div className="aspect-video w-full overflow-hidden bg-gray-100">
+          <img
+            src={imageUrl}
+            alt={title}
+            className="h-full w-full object-cover transition-transform group-hover:scale-105"
+          />
+        </div>
+      ) : (
+        <div className="aspect-video w-full bg-gradient-to-br from-gray-100 to-gray-200" />
+      )}
+
+      <div className="p-6">
+        {/* カテゴリと期間 */}
+        <div className="mb-3 flex items-center justify-between text-sm text-gray-500">
+          <span className="rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700">
+            {category}
+          </span>
+          <span>{period}</span>
+        </div>
+
+        {/* タイトル */}
+        <h3 className="mb-2 text-xl font-bold text-gray-900">{title}</h3>
+
+        {/* 説明 */}
+        <p className="mb-4 text-sm text-gray-600 line-clamp-3">{description}</p>
+
+        {/* 技術タグ */}
+        <div className="mb-4 flex flex-wrap gap-2">
+          {technologies.map((tech) => (
+            <span
+              key={tech}
+              className="rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-700"
+            >
+              {tech}
+            </span>
+          ))}
+        </div>
+
+        {/* リンク */}
+        <div className="flex gap-3">
+          {githubUrl && (
+            <Link
+              href={githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-sm text-gray-700 transition-colors hover:text-gray-900"
+              aria-label={`${title} GitHub repository`}
+            >
+              <Github className="h-4 w-4" />
+              <span>GitHub</span>
+            </Link>
+          )}
+          {demoUrl && (
+            <Link
+              href={demoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-sm text-gray-700 transition-colors hover:text-gray-900"
+              aria-label={`${title} demo site`}
+            >
+              <ExternalLink className="h-4 w-4" />
+              <span>Demo</span>
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { ProjectCard }

--- a/components/__tests__/ProjectCard.test.tsx
+++ b/components/__tests__/ProjectCard.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react'
+import { ProjectCard } from '@/components/ProjectCard'
+
+describe('ProjectCard', () => {
+  const defaultProps = {
+    title: 'Test Project',
+    description: 'This is a test project description',
+    technologies: ['React', 'TypeScript', 'Tailwind CSS'],
+    period: '2024年11月',
+    category: '自主制作',
+  }
+
+  it('should render project title as h3 heading', () => {
+    render(<ProjectCard {...defaultProps} />)
+
+    const heading = screen.getByRole('heading', { level: 3, name: 'Test Project' })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('should render project description', () => {
+    render(<ProjectCard {...defaultProps} />)
+
+    expect(screen.getByText('This is a test project description')).toBeInTheDocument()
+  })
+
+  it('should render category badge', () => {
+    render(<ProjectCard {...defaultProps} />)
+
+    expect(screen.getByText('自主制作')).toBeInTheDocument()
+  })
+
+  it('should render period', () => {
+    render(<ProjectCard {...defaultProps} />)
+
+    expect(screen.getByText('2024年11月')).toBeInTheDocument()
+  })
+
+  it('should render all technology tags', () => {
+    render(<ProjectCard {...defaultProps} />)
+
+    expect(screen.getByText('React')).toBeInTheDocument()
+    expect(screen.getByText('TypeScript')).toBeInTheDocument()
+    expect(screen.getByText('Tailwind CSS')).toBeInTheDocument()
+  })
+
+  it('should render GitHub link when githubUrl is provided', () => {
+    render(
+      <ProjectCard
+        {...defaultProps}
+        githubUrl="https://github.com/test/repo"
+      />
+    )
+
+    const githubLink = screen.getByRole('link', { name: /github/i })
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/test/repo')
+    expect(githubLink).toHaveAttribute('target', '_blank')
+    expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('should render Demo link when demoUrl is provided', () => {
+    render(
+      <ProjectCard
+        {...defaultProps}
+        demoUrl="https://demo.example.com"
+      />
+    )
+
+    const demoLink = screen.getByRole('link', { name: /demo/i })
+    expect(demoLink).toHaveAttribute('href', 'https://demo.example.com')
+    expect(demoLink).toHaveAttribute('target', '_blank')
+    expect(demoLink).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('should not render links when URLs are not provided', () => {
+    render(<ProjectCard {...defaultProps} />)
+
+    expect(screen.queryByRole('link', { name: /github/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /demo/i })).not.toBeInTheDocument()
+  })
+
+  it('should render image when imageUrl is provided', () => {
+    render(
+      <ProjectCard
+        {...defaultProps}
+        imageUrl="/test-image.jpg"
+      />
+    )
+
+    const image = screen.getByAltText('Test Project')
+    expect(image).toBeInTheDocument()
+    expect(image).toHaveAttribute('src', '/test-image.jpg')
+  })
+
+  it('should render placeholder when imageUrl is not provided', () => {
+    const { container } = render(<ProjectCard {...defaultProps} />)
+
+    const placeholder = container.querySelector('.bg-gradient-to-br')
+    expect(placeholder).toBeInTheDocument()
+  })
+
+  it('should render with different category', () => {
+    render(
+      <ProjectCard
+        {...defaultProps}
+        category="インターンシップ"
+      />
+    )
+
+    expect(screen.getByText('インターンシップ')).toBeInTheDocument()
+  })
+})

--- a/pages/work.tsx
+++ b/pages/work.tsx
@@ -1,0 +1,73 @@
+import { Layout } from '@/components/Layout'
+import { ProjectCard } from '@/components/ProjectCard'
+
+const WorkPage = () => {
+  const projects = [
+    {
+      title: 'ポートフォリオサイト',
+      description:
+        '自己紹介や制作物を紹介するポートフォリオサイトです。Next.js、TypeScript、Tailwind CSSを使用して開発しました。レスポンシブデザインとアクセシビリティを重視しています。',
+      technologies: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Jest'],
+      period: '2024年11月',
+      category: '自主制作',
+      githubUrl: 'https://github.com/masaya0322/portfolio',
+      demoUrl: 'https://portfolio-example.com',
+    },
+    {
+      title: 'タスク管理アプリ',
+      description:
+        'シンプルで使いやすいタスク管理アプリケーションです。Reactを使用し、ドラッグ&ドロップでタスクを管理できる機能を実装しました。',
+      technologies: ['React', 'TypeScript', 'CSS Modules'],
+      period: '2024年9月',
+      category: '自主制作',
+      githubUrl: 'https://github.com/masaya0322/task-app',
+    },
+    {
+      title: '社内管理システム',
+      description:
+        'インターンシップで開発に携わった社内管理システムのフロントエンド部分です。UIコンポーネントの実装とAPIとの連携を担当しました。',
+      technologies: ['React', 'TypeScript', 'Material-UI', 'REST API'],
+      period: '2024年8月 - 9月',
+      category: 'インターンシップ',
+    },
+    {
+      title: '天気予報アプリ',
+      description:
+        '外部APIを使用した天気予報アプリです。現在地の天気情報を取得し、分かりやすく表示します。',
+      technologies: ['JavaScript', 'HTML', 'CSS', 'Weather API'],
+      period: '2024年7月',
+      category: '自主制作',
+      githubUrl: 'https://github.com/masaya0322/weather-app',
+      demoUrl: 'https://weather-app-example.com',
+    },
+  ]
+
+  return (
+    <Layout>
+      {/* ヒーローセクション */}
+      <section className="bg-gradient-to-b from-gray-50 to-white px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Work
+          </h1>
+          <p className="mt-6 text-lg text-gray-600">
+            これまでの制作物やプロジェクトを紹介します
+          </p>
+        </div>
+      </section>
+
+      {/* 制作物一覧セクション */}
+      <section className="px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {projects.map((project) => (
+              <ProjectCard key={project.title} {...project} />
+            ))}
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export default WorkPage


### PR DESCRIPTION
## Summary

WORKページを実装し、制作物を一覧表示する機能を追加しました。

### 追加した機能
- **ProjectCardコンポーネント**: プロジェクト情報を表示するカードコンポーネント
  - タイトル、説明文、技術スタック、制作期間、カテゴリーを表示
  - GitHub/Demoリンクの表示（オプション）
  - プロジェクト画像の表示（オプション、未提供時はプレースホルダー表示）
  - ホバー時のアニメーション効果（カード全体のシャドウ、画像の拡大）
  
- **WORKページ**: 制作物を一覧表示するページ
  - レスポンシブグリッドレイアウト（モバイル: 1列、タブレット: 2列、デスクトップ: 3列）
  - ヒーローセクション: ページタイトルと説明文
  - プロジェクト一覧セクション: 4つのサンプルプロジェクトを表示
  - 各プロジェクトには技術スタック、期間、カテゴリー、外部リンクを含む

### テストカバレッジ
- **ProjectCardコンポーネント**: 11テスト（全てパス）
  - タイトルのh3表示確認
  - 説明文、カテゴリー、期間の表示確認
  - 技術タグの全表示確認
  - GitHubリンクの条件付き表示確認（href, target, rel属性含む）
  - Demoリンクの条件付き表示確認（href, target, rel属性含む）
  - リンクなしの場合の非表示確認
  - 画像表示の確認（imageUrl提供時）
  - プレースホルダー表示の確認（imageUrl未提供時）
  - カテゴリー変更の確認

- **WORKページ**: 9テスト（全てパス）
  - ページタイトル（h1）の表示確認
  - ページ説明文の表示確認
  - 全プロジェクトカード（4枚）の表示確認
  - カテゴリーバッジの表示確認
  - 制作期間の表示確認
  - GitHubリンクの表示確認
  - Demoリンクの表示確認
  - セマンティック構造の確認（main, navigation）
  - 技術タグの表示確認（複数出現を考慮）

### 変更内容
- `components/ProjectCard.tsx`: 99行（新規作成）
- `pages/work.tsx`: 73行（新規作成）
- `components/__tests__/ProjectCard.test.tsx`: 111行（新規作成）
- `__tests__/pages/work.test.tsx`: 70行（新規作成）
- **合計**: 353行

## Test plan

- [x] 全テスト実行（20テスト全てパス）
- [x] ビルド成功確認
- [x] レスポンシブレイアウトの動作確認
- [x] リンクの外部遷移確認
- [x] アクセシビリティの確認（aria-label, セマンティックHTML）
- [x] プレースホルダー画像の表示確認

Resolves #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)