### PR TITLE
feat: create WORK page skeleton

### DIFF
--- a/__tests__/pages/work.test.tsx
+++ b/__tests__/pages/work.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import WorkPage from '@/pages/work'
+
+describe('WorkPage', () => {
+  it('should render page title', () => {
+    render(<WorkPage />)
+
+    const heading = screen.getByRole('heading', { level: 1, name: /work/i })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('should render page description', () => {
+    render(<WorkPage />)
+
+    expect(screen.getByText(/これまでの制作物やプロジェクトを紹介します/i)).toBeInTheDocument()
+  })
+
+  it('should render coming soon placeholder', () => {
+    render(<WorkPage />)
+
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument()
+    expect(screen.getByText(/プロジェクト一覧は準備中です/i)).toBeInTheDocument()
+  })
+
+  it('should have semantic structure', () => {
+    render(<WorkPage />)
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+  })
+})

--- a/pages/work.tsx
+++ b/pages/work.tsx
@@ -1,0 +1,33 @@
+import { Layout } from '@/components/Layout'
+
+const WorkPage = () => {
+  return (
+    <Layout>
+      {/* ヒーローセクション */}
+      <section className="bg-gradient-to-b from-gray-50 to-white px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Work
+          </h1>
+          <p className="mt-6 text-lg text-gray-600">
+            これまでの制作物やプロジェクトを紹介します
+          </p>
+        </div>
+      </section>
+
+      {/* プレースホルダーセクション */}
+      <section className="px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <div className="rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 p-12 text-center">
+            <p className="text-xl text-gray-500">Coming Soon...</p>
+            <p className="mt-2 text-sm text-gray-400">
+              プロジェクト一覧は準備中です
+            </p>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export default WorkPage


### PR DESCRIPTION
## Summary

WORKページの骨組みを作成しました。動作確認できる最小限の実装です。

### 追加した機能
- **WORKページ**: ページの基本構造のみ
  - Layoutコンポーネントを使用した共通レイアウト
  - ヒーローセクション: ページタイトル「Work」と説明文
  - プレースホルダーセクション: 「Coming Soon...」表示

### テストカバレッジ
- **WORKページ**: 4テスト（全てパス）
  - ページタイトル（h1）の表示確認
  - 説明文の表示確認
  - Coming Soonプレースホルダーの表示確認
  - セマンティック構造の確認（main, navigation）

### 変更内容
- `pages/work.tsx`: 33行（新規作成）
- `__tests__/pages/work.test.tsx`: 29行（新規作成）
- **合計**: 62行

## Test plan

- [x] 全テスト実行（4テスト全てパス）
- [x] ビルド成功確認
- [x] レスポンシブレイアウトの動作確認
- [x] セマンティックHTMLの確認

## 次のステップ

このPRマージ後、別ISSUE（#11）でProjectCardコンポーネントを作成し、プロジェクト一覧機能を追加します。

Resolves #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)