### PR TITLE
feat: create SKILL page skeleton

### DIFF
--- a/__tests__/pages/skill.test.tsx
+++ b/__tests__/pages/skill.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, within } from '@testing-library/react'
+import SkillPage from '@/pages/skill'
+
+describe('SkillPage', () => {
+  it('should render page title', () => {
+    render(<SkillPage />)
+
+    const heading = screen.getByRole('heading', { level: 1, name: /skills/i })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('should render page description', () => {
+    render(<SkillPage />)
+
+    expect(screen.getByText(/技術スキルと開発経験のある言語・ツールを紹介します/i)).toBeInTheDocument()
+  })
+
+  it('should have semantic structure', () => {
+    render(<SkillPage />)
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+  })
+
+  describe('Programming Languages Section', () => {
+    it('should render programming languages heading and icon', () => {
+      render(<SkillPage />)
+
+      const languagesHeading = screen.getByRole('heading', { level: 2, name: /プログラミング言語/i })
+      expect(languagesHeading).toBeInTheDocument()
+
+      const section = languagesHeading.closest('section')
+      const icons = section?.querySelectorAll('svg')
+      expect(icons!.length).toBeGreaterThan(0)
+    })
+
+    it('should render programming languages section', () => {
+      render(<SkillPage />)
+
+      const languagesHeading = screen.getByRole('heading', { level: 2, name: /プログラミング言語/i })
+      const languagesSection = languagesHeading.closest('section')
+
+      expect(languagesSection).toBeInTheDocument()
+    })
+  })
+
+  describe('Frameworks and Libraries Section', () => {
+    it('should render frameworks heading and icon', () => {
+      render(<SkillPage />)
+
+      const frameworksHeading = screen.getByRole('heading', {
+        level: 2,
+        name: /フレームワーク・ライブラリ/i,
+      })
+      expect(frameworksHeading).toBeInTheDocument()
+
+      const section = frameworksHeading.closest('section')
+      const icons = section?.querySelectorAll('svg')
+      expect(icons!.length).toBeGreaterThan(0)
+    })
+
+    it('should render frameworks section', () => {
+      render(<SkillPage />)
+
+      const frameworksHeading = screen.getByRole('heading', {
+        level: 2,
+        name: /フレームワーク・ライブラリ/i,
+      })
+      const frameworksSection = frameworksHeading.closest('section')
+
+      expect(frameworksSection).toBeInTheDocument()
+    })
+  })
+
+  describe('Tools and Technologies Section', () => {
+    it('should render tools heading and icon', () => {
+      render(<SkillPage />)
+
+      const toolsHeading = screen.getByRole('heading', { level: 2, name: /ツール・技術/i })
+      expect(toolsHeading).toBeInTheDocument()
+
+      const section = toolsHeading.closest('section')
+      const icons = section?.querySelectorAll('svg')
+      expect(icons!.length).toBeGreaterThan(0)
+    })
+
+    it('should render tools section', () => {
+      render(<SkillPage />)
+
+      const toolsHeading = screen.getByRole('heading', { level: 2, name: /ツール・技術/i })
+      const toolsSection = toolsHeading.closest('section')
+
+      expect(toolsSection).toBeInTheDocument()
+    })
+  })
+
+  describe('All Sections Structure', () => {
+    it('should render all main sections with h2 headings', () => {
+      render(<SkillPage />)
+
+      const expectedH2Headings = [
+        /プログラミング言語/i,
+        /フレームワーク・ライブラリ/i,
+        /ツール・技術/i,
+      ]
+
+      expectedH2Headings.forEach((headingPattern) => {
+        const heading = screen.getByRole('heading', { level: 2, name: headingPattern })
+        expect(heading).toBeInTheDocument()
+      })
+    })
+
+    it('should render icons for all sections', () => {
+      const { container } = render(<SkillPage />)
+
+      const allSvgIcons = container.querySelectorAll('svg')
+      expect(allSvgIcons.length).toBeGreaterThanOrEqual(3)
+    })
+  })
+})

--- a/pages/skill.tsx
+++ b/pages/skill.tsx
@@ -1,0 +1,56 @@
+import { Layout } from '@/components/Layout'
+import { SectionHeader } from '@/components/SectionHeader'
+import { ContentCard } from '@/components/ContentCard'
+import { Code, Package, Wrench } from 'lucide-react'
+
+const SkillPage = () => {
+  return (
+    <Layout>
+      <section className="bg-gradient-to-b from-gray-50 to-white px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Skills</h1>
+          <p className="mt-6 text-lg text-gray-600">技術スキルと開発経験のある言語・ツールを紹介します</p>
+        </div>
+      </section>
+
+      <section className="px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto">
+          <SectionHeader icon={Code} title="プログラミング言語" />
+          <ContentCard>
+            <p className="text-gray-600">プログラミング言語のスキルを表示します</p>
+          </ContentCard>
+        </div>
+      </section>
+
+      <section className="px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto">
+          <SectionHeader
+            icon={Package}
+            title="フレームワーク・ライブラリ"
+            iconBgColor="bg-green-100"
+            iconColor="text-green-600"
+          />
+          <ContentCard>
+            <p className="text-gray-600">フレームワーク・ライブラリのスキルを表示します</p>
+          </ContentCard>
+        </div>
+      </section>
+
+      <section className="px-4 py-12 pb-20 sm:px-6 lg:px-8">
+        <div className="mx-auto">
+          <SectionHeader
+            icon={Wrench}
+            title="ツール・技術"
+            iconBgColor="bg-purple-100"
+            iconColor="text-purple-600"
+          />
+          <ContentCard>
+            <p className="text-gray-600">開発ツールと技術スタックを表示します</p>
+          </ContentCard>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export default SkillPage


### PR DESCRIPTION
## Summary
Create the basic structure and skeleton for the SKILL page.

Closes #33

## Changes
- **pages/skill.tsx**: New SKILL page implementation with three main sections:
  - Programming Languages section with Code icon
  - Frameworks & Libraries section with Package icon
  - Tools & Technologies section with Wrench icon
- **__tests__/pages/skill.test.tsx**: Comprehensive test coverage for all sections

## Technical Details
- Uses Layout, SectionHeader, and ContentCard components
- Responsive design with Tailwind CSS
- Semantic HTML structure
- Arrow function implementation

## Test Plan
- [x] Page renders correctly with title and description
- [x] All three sections render with proper headings and icons
- [x] Semantic HTML structure is maintained
- [x] All tests pass (11/11)
- [x] No TypeScript errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)