### PR TITLE
feat: create CONTACT page skeleton

### DIFF
--- a/__tests__/pages/contact.test.tsx
+++ b/__tests__/pages/contact.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, within } from '@testing-library/react'
+import ContactPage from '@/pages/contact'
+
+describe('ContactPage', () => {
+  it('should render page title', () => {
+    render(<ContactPage />)
+
+    const heading = screen.getByRole('heading', { level: 1, name: /contact/i })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('should render page description', () => {
+    render(<ContactPage />)
+
+    expect(screen.getByText(/お気軽にお問い合わせください/i)).toBeInTheDocument()
+  })
+
+  it('should have semantic structure', () => {
+    render(<ContactPage />)
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+  })
+
+  describe('Contact Information Section', () => {
+    it('should render contact information heading', () => {
+      render(<ContactPage />)
+
+      const contactHeading = screen.getByRole('heading', { level: 2, name: /連絡先/i })
+      expect(contactHeading).toBeInTheDocument()
+    })
+
+    it('should render GitHub link', () => {
+      render(<ContactPage />)
+
+      expect(screen.getByRole('heading', { level: 3, name: /github/i })).toBeInTheDocument()
+      const githubLink = screen.getByRole('link', { name: /@masaya0322/i })
+      expect(githubLink).toHaveAttribute('href', 'https://github.com/masaya0322')
+      expect(githubLink).toHaveAttribute('target', '_blank')
+      expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('should render Twitter information', () => {
+      render(<ContactPage />)
+
+      expect(screen.getByRole('heading', { level: 3, name: /twitter/i })).toBeInTheDocument()
+      expect(screen.getByText(/@your_twitter/i)).toBeInTheDocument()
+    })
+
+    it('should render Email information', () => {
+      render(<ContactPage />)
+
+      expect(screen.getByRole('heading', { level: 3, name: /email/i })).toBeInTheDocument()
+      expect(screen.getByText(/your\.email@example\.com/i)).toBeInTheDocument()
+    })
+
+    it('should render contact information with icons', () => {
+      const { container } = render(<ContactPage />)
+
+      const contactSection = screen.getByRole('heading', { level: 2, name: /連絡先/i }).closest('section')
+      const icons = contactSection?.querySelectorAll('svg')
+      expect(icons!.length).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('Contact Form Section', () => {
+    it('should render contact form heading', () => {
+      render(<ContactPage />)
+
+      const formHeading = screen.getByRole('heading', { level: 2, name: /お問い合わせ/i })
+      expect(formHeading).toBeInTheDocument()
+    })
+
+    it('should render form section', () => {
+      render(<ContactPage />)
+
+      const formHeading = screen.getByRole('heading', { level: 2, name: /お問い合わせ/i })
+      const formSection = formHeading.closest('section')
+
+      expect(formSection).toBeInTheDocument()
+    })
+  })
+
+  describe('All Sections Structure', () => {
+    it('should render all main sections with h2 headings', () => {
+      render(<ContactPage />)
+
+      const expectedH2Headings = [/連絡先/i, /お問い合わせ/i]
+
+      expectedH2Headings.forEach((headingPattern) => {
+        const heading = screen.getByRole('heading', { level: 2, name: headingPattern })
+        expect(heading).toBeInTheDocument()
+      })
+    })
+
+    it('should render icons for sections', () => {
+      const { container } = render(<ContactPage />)
+
+      const allSvgIcons = container.querySelectorAll('svg')
+      expect(allSvgIcons.length).toBeGreaterThanOrEqual(4)
+    })
+  })
+})

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,79 @@
+import { Layout } from '@/components/Layout'
+import { SectionHeader } from '@/components/SectionHeader'
+import { ContentCard } from '@/components/ContentCard'
+import { Github, Mail, Twitter } from 'lucide-react'
+
+const ContactPage = () => {
+  return (
+    <Layout>
+      <section className="bg-gradient-to-b from-gray-50 to-white px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Contact</h1>
+          <p className="mt-6 text-lg text-gray-600">お気軽にお問い合わせください</p>
+        </div>
+      </section>
+
+      <section className="px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <SectionHeader icon={Mail} title="連絡先" />
+          <ContentCard>
+            <div className="space-y-6">
+              <div className="flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+                  <Github className="h-6 w-6 text-gray-700" />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-gray-900">GitHub</h3>
+                  <a
+                    href="https://github.com/masaya0322"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-blue-600 hover:underline"
+                  >
+                    @masaya0322
+                  </a>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+                  <Twitter className="h-6 w-6 text-gray-700" />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-gray-900">Twitter</h3>
+                  <p className="text-sm text-gray-600">@your_twitter</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+                  <Mail className="h-6 w-6 text-gray-700" />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-gray-900">Email</h3>
+                  <p className="text-sm text-gray-600">your.email@example.com</p>
+                </div>
+              </div>
+            </div>
+          </ContentCard>
+        </div>
+      </section>
+
+      <section className="px-4 py-12 pb-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <SectionHeader
+            icon={Mail}
+            title="お問い合わせ"
+            iconBgColor="bg-green-100"
+            iconColor="text-green-600"
+          />
+          <ContentCard>
+            <p className="text-gray-600">お問い合わせフォームを実装予定</p>
+          </ContentCard>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export default ContactPage


### PR DESCRIPTION
## Summary
Create the basic structure and skeleton for the CONTACT page.

Closes #37

## Changes
- **pages/contact.tsx**: New CONTACT page implementation with:
  - Contact information section with GitHub, Twitter, and Email
  - External GitHub link with proper attributes (target="_blank", rel="noopener noreferrer")
  - Icons using lucide-react (Github, Twitter, Mail)
  - Contact form section placeholder

- **__tests__/pages/contact.test.tsx**: Comprehensive test coverage for all sections
  - Page structure tests
  - Contact information rendering tests
  - External link validation
  - Icon rendering tests

## Technical Details
- Uses Layout, SectionHeader, and ContentCard components
- Responsive design with Tailwind CSS
- Semantic HTML structure
- Arrow function implementation
- Max-width container for better readability

## Test Plan
- [x] Page renders correctly with title and description
- [x] Contact information section renders with all links
- [x] GitHub link has proper external link attributes
- [x] Icons are displayed correctly
- [x] Semantic HTML structure is maintained
- [x] All tests pass (12/12)
- [x] No TypeScript errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)