### PR TITLE
test: SectionCardのモバイルレイアウトテストを更新・追加

### DIFF
--- a/__tests__/components/SectionCard.test.tsx
+++ b/__tests__/components/SectionCard.test.tsx
@@ -91,6 +91,7 @@ describe('SectionCard', () => {
     expect(image).toBeInTheDocument()
 
     const flexContainer = container.querySelector('.flex')
+    expect(flexContainer).toHaveClass('flex-col')
     expect(flexContainer).toHaveClass('md:flex-row')
   })
 
@@ -107,6 +108,7 @@ describe('SectionCard', () => {
     expect(image).toBeInTheDocument()
 
     const flexContainer = container.querySelector('.flex')
+    expect(flexContainer).toHaveClass('flex-col')
     expect(flexContainer).toHaveClass('md:flex-row-reverse')
   })
 
@@ -124,5 +126,33 @@ describe('SectionCard', () => {
 
     const svgElements = container.querySelectorAll('svg')
     expect(svgElements.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should apply mobile-first layout with flex-col for images', () => {
+    const propsWithImage = {
+      ...defaultProps,
+      imageUrl: '/test-image.jpg',
+    }
+
+    const { container } = render(<SectionCard {...propsWithImage} />)
+
+    const flexContainer = container.querySelector('.flex')
+    expect(flexContainer).toHaveClass('flex-col')
+  })
+
+  it('should apply correct responsive classes for mobile and desktop', () => {
+    const propsWithImageRight = {
+      ...defaultProps,
+      imageUrl: '/test-image.jpg',
+      imagePosition: 'right' as const,
+    }
+
+    const { container } = render(<SectionCard {...propsWithImageRight} />)
+
+    const flexContainer = container.querySelector('.flex')
+    const classList = flexContainer?.className || ''
+
+    expect(classList).toContain('flex-col')
+    expect(classList).toContain('md:flex-row-reverse')
   })
 })

--- a/components/SectionCard.tsx
+++ b/components/SectionCard.tsx
@@ -21,7 +21,7 @@ const SectionCard = ({
   imagePosition = 'right',
 }: SectionCardProps) => {
   const hasImage = !!imageUrl
-  const flexDirectionClass = imagePosition !== 'left' ? 'md:flex-row-reverse' : 'md:flex-row'
+  const flexDirectionClass = imagePosition !== 'left' ? 'flex-col md:flex-row-reverse' : 'flex-col md:flex-row'
 
   if (hasImage) {
     return (


### PR DESCRIPTION
## 概要
SectionCardコンポーネントのモバイルレイアウト対応に伴い、テストケースを更新・追加しました。

## 変更内容

### テストの更新
1. **既存テストの更新** (`__tests__/components/SectionCard.test.tsx:94, 111`)
   - `imagePosition='left'`のテストに`flex-col`クラスのアサーションを追加
   - `imagePosition='right'`のテストに`flex-col`クラスのアサーションを追加

2. **新規テストの追加**
   - モバイルファーストレイアウトを検証するテストケース
   - レスポンシブクラスが正しく適用されることを確認するテストケース

### コンポーネントの更新
- `components/SectionCard.tsx:24`の`flexDirectionClass`にモバイル用の`flex-col`クラスを追加
- モバイルデバイスでは縦並び、タブレット以上では横並びのレスポンシブレイアウトを実現

## テスト結果
```
✓ should render as a link with correct href
✓ should render title as h2 heading
✓ should render description text
✓ should render icon and arrow icon
✓ should render call-to-action text with arrow
✓ should render with different icon and props
✓ should render with image when imageUrl is provided
✓ should render with image on the left when imagePosition is left
✓ should render with image on the right when imagePosition is right
✓ should render all content elements when image is present
✓ should apply mobile-first layout with flex-col for images
✓ should apply correct responsive classes for mobile and desktop

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
```

## 検証内容
- モバイルデバイス（デフォルト）: `flex-col`による縦並びレイアウト
- タブレット以上（`md:`ブレークポイント）: `md:flex-row`または`md:flex-row-reverse`による横並びレイアウト
- 既存の機能が正しく動作することを確認

## 関連PR
- #69: モバイルデバイスでSectionCardの画像が上に表示されるように修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)